### PR TITLE
Use debug module instead of console.log to avoid excessive logging

### DIFF
--- a/raymarinen2k.js
+++ b/raymarinen2k.js
@@ -70,7 +70,7 @@ module.exports = function(app) {
       timers.push(setInterval(() => {
         const msg = util.format(keep_alive2, (new Date()).toISOString(),
                                 default_src)
-        console.log('sending keep_alive: ' + msg)
+        app.debug('sending keep_alive: ' + msg)
         app.emit('nmea2000out', msg)
       }, 2000))
     }


### PR DESCRIPTION
When e.g. running SignalK server as a systemd service, the Linux journal is flooded with output from this plugin. This change fixes that while still allowing to see the heartbeat messages if needed by enabling debug mode.