### PR TITLE
Update to accomodate ShipModul Miniplex

### DIFF
--- a/raymarinest.js
+++ b/raymarinest.js
@@ -68,6 +68,7 @@ module.exports = function(app) {
 
     var sentence = toSentence([
       '$PSMDST',
+      'C',
       datagram
     ])
     app.emit(outputEvent, sentence)


### PR DESCRIPTION
The Shipmodul Miniplex now uses R and C to represent a message being received or sent. This update adds C to each PSMDST message so that the Miniplex will accept the message.

Example: $PSMDST,C,XX,YY,ZZ