### PR TITLE
feature: add support for Autopilot API

### DIFF
--- a/index.js
+++ b/index.js
@@ -339,7 +339,7 @@ module.exports = function(app) {
             // map n2k device target value to API.target
             if (
               pathValue.path === 'steering.autopilot.target.windAngleApparent' &&
-              apData.mode === 'wind'
+              apData.state === 'wind'
             ) {
               apData.target = pathValue.value
               app.autopilotUpdate(apType, {target: pathValue.value})
@@ -348,7 +348,7 @@ module.exports = function(app) {
             if (
               (pathValue.path === 'steering.autopilot.target.headingTrue' ||
               pathValue.path === 'steering.autopilot.target.headingMagnetic') &&
-              apData.mode !== 'wind'
+              apData.state !== 'wind'
             ) {
               apData.target = pathValue.value
               app.autopilotUpdate(apType, {target: pathValue.value})

--- a/index.js
+++ b/index.js
@@ -218,12 +218,12 @@ module.exports = function(app) {
             return apData.target
           },
           setTarget: async (value, deviceId) => {
-            if ( apData.mode === 'auto' ) {
+            if ( apData.state === 'auto' ) {
               const r = autopilot.putTargetHeading(undefined, undefined, radiansToDegrees(value), undefined)
               if (r.state === 'FAILURE') {
                 throw new Error(r.message)
               }
-            } else if ( apData.mode === 'wind' ) {
+            } else if ( apData.state === 'wind' ) {
               const r = autopilot.putTargetWind(undefined, undefined, radiansToDegrees(value), undefined)
               if (r.state === 'FAILURE') {
                 throw new Error(r.message)

--- a/index.js
+++ b/index.js
@@ -95,9 +95,6 @@ module.exports = function(app) {
                            advance,
                            autopilot.putAdvanceWaypoint)
 
-    registerProvider()
-
-
     app.handleMessage(plugin.id, {
       updates: [
           {
@@ -131,6 +128,8 @@ module.exports = function(app) {
           }
       ]
     })
+
+    registerProvider()
   }
   
   plugin.stop = function() {

--- a/index.js
+++ b/index.js
@@ -200,10 +200,7 @@ module.exports = function(app) {
             deviceId
           ) => {
             if (isValidState(state)) {
-              const r = autopilot.putState(undefined, undefined, state, undefined)
-              if (r.state === 'FAILURE') {
-                throw new Error(r.message)
-              }
+              return autopilot.putStatePromise(undefined, undefined, state, undefined)
             } else {
               throw new Error(`${state} is not a valid value!`)
             }
@@ -219,51 +216,30 @@ module.exports = function(app) {
           },
           setTarget: async (value, deviceId) => {
             if ( apData.state === 'auto' ) {
-              const r = autopilot.putTargetHeading(undefined, undefined, radiansToDegrees(value), undefined)
-              if (r.state === 'FAILURE') {
-                throw new Error(r.message)
-              }
+              return autopilot.putTargetHeadingPromise(undefined, undefined, radiansToDegrees(value), undefined)
             } else if ( apData.state === 'wind' ) {
-              const r = autopilot.putTargetWind(undefined, undefined, radiansToDegrees(value), undefined)
-              if (r.state === 'FAILURE') {
-                throw new Error(r.message)
-              }
+              return autopilot.putTargetWindPromise(undefined, undefined, radiansToDegrees(value), undefined)
             } else {
               throw new Error(`Unable to set target value! STATE = ${apData.state}`)
-            }
-            
+            } 
           },
           adjustTarget: async (
             value,
             deviceId
           ) => {
-            const r = autopilot.putAdjustHeading(undefined, undefined, Math.floor(radiansToDegrees(value)), undefined)
-            if (r.state === 'FAILURE') {
-              throw new Error(r.message)
-            }
-            return
+            return autopilot.putAdjustHeadingPromise(undefined, undefined, Math.floor(radiansToDegrees(value)), undefined)
           },
           engage: async (deviceId) => {
-            const r = autopilot.putState(undefined, undefined, defaultEngagedState, undefined)
-            if (r.state === 'FAILURE') {
-              throw new Error(r.message) 
-            }
-            return
+            return autopilot.putStatePromise(undefined, undefined, defaultEngagedState, undefined)
           },
           disengage: async (deviceId) => {
-            const r = autopilot.putState(undefined, undefined, 'standby', undefined)
-            if (r.state === 'FAILURE') {
-              throw new Error(r.message)
-            }
-            return
+            return autopilot.putStatePromise(undefined, undefined, 'standby', undefined)           
           },
           tack: async (
             direction,
             deviceId
           ) => {
-            const r = autopilot.putTack(undefined, undefined, direction, undefined)
-            if (r.state === 'FAILURE') { throw new Error(r.message) }
-            return
+            return autopilot.putTackPromise(undefined, undefined, direction, undefined)
           },
           gybe: async (
             direction,

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const apData = {
       {name: 'route', engaged: true},
       {name: 'standby', engaged: false}
     ],
-    modes: []
+    modes: ['auto', 'wind', 'route']
   },
   mode: null,
   state: null,
@@ -200,10 +200,18 @@ module.exports = function(app) {
             }
           },
           getMode: async (deviceId) => {
-            throw new Error('Not implemented!')
+            return apData.mode
           },
           setMode: async (mode, deviceId) => {
-            throw new Error('Not implemented!')
+            const r = autopilot.putState(
+              undefined, 
+              undefined, 
+              mode, 
+              undefined
+            )
+            if (r.state === 'FAILURE') {
+              throw new Error(r.message)
+            }
           },
           getTarget: async (deviceId) => {
             return apData.target
@@ -211,12 +219,12 @@ module.exports = function(app) {
           setTarget: async (value, deviceId) => {
             const apState = apData.state
             if ( apState === 'auto' ) {
-              const r = autopilot.putTargetHeading(undefined, undefined, value, undefined)
+              const r = autopilot.putTargetHeading(undefined, undefined, radiansToDegrees(value), undefined)
               if (r.state === 'FAILURE') {
                 throw new Error(r.message)
               }
             } else if ( apState === 'wind' ) {
-              const r = autopilot.putTargetWind(undefined, undefined, value, undefined)
+              const r = autopilot.putTargetWind(undefined, undefined, radiansToDegrees(value), undefined)
               if (r.state === 'FAILURE') {
                 throw new Error(r.message)
               }
@@ -227,7 +235,7 @@ module.exports = function(app) {
             value,
             deviceId
           ) => {
-            const r = autopilot.putAdjustHeading(undefined, undefined, value, undefined)
+            const r = autopilot.putAdjustHeading(undefined, undefined, Math.floor(radiansToDegrees(value)), undefined)
             if (r.state === 'FAILURE') {
               throw new Error(r.message)
             }
@@ -385,33 +393,41 @@ module.exports = function(app) {
         })
       }
       else if ( mode == 0 && subMode == 1 ) {
+        apData.mode = 'wind'
         apData.state = 'wind'
         apData.engaged = true
         app.autopilotUpdate(apType, {
+          mode: apData.mode,
           state: apData.state,
           engaged: true
         })
       }
       else if ( (mode == 128 || mode == 129) && subMode == 1 ) {
+        apData.mode = 'route'
         apData.state = 'route'
         apData.engaged = true
         app.autopilotUpdate(apType, {
+          mode: apData.mode,
           state: apData.state,
           engaged: true
         })
       }
       else if ( mode == 2 && subMode == 0 ) {
+        apData.mode = 'route'
         apData.state = 'route'
         apData.engaged = true
         app.autopilotUpdate(apType, {
+          mode: apData.mode,
           state: apData.state,
           engaged: true
         })
       }
       else if ( mode == 64 && subMode == 0 ) {
+        apData.mode = 'auto'
         apData.state = 'auto'
         apData.engaged = true
         app.autopilotUpdate(apType, {
+          mode: apData.mode,
           state: apData.state,
           engaged: true
         })

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function(app) {
     apType= props.type
     autopilot = pilots[props.type]
     autopilot.start(props)
-    app.debug('autopilot.id:', autopilot.id, apType)
+    app.debug('autopilot.id:', autopilot.id, 'autopilot.type:', apType)
 
     app.registerPutHandler('vessels.self',
                            state_path,
@@ -246,7 +246,7 @@ module.exports = function(app) {
       127237
     ]
    
-    if (!pgns.includes(evt.pgn) || evt.src !== autopilot.id) {
+    if (!pgns.includes(evt.pgn) || String(evt.src) !== autopilot.id) {
       return
     }
    

--- a/raymarinen2k.js
+++ b/raymarinen2k.js
@@ -59,7 +59,7 @@ module.exports = function(app) {
 
   pilot.start = (props) => {
     deviceid = props.deviceid
-    pilot.id = Number(deviceid)
+    pilot.id = deviceid
     app.debug('props.deviceid:', deviceid)
 
     if ( props.controlHead ) {
@@ -189,8 +189,10 @@ module.exports = function(app) {
   }
 
   pilot.properties = () => {
-    let defaultId = '205'
+    let defaultId = deviceid ?? '205'
     let description = 'No EV-1 Found'
+
+    app.debug('***pre-discovery -> defaultId', defaultId)
 
     if ( !discovered ) {
       //let full = app.deltaCache.buildFull(undefined, [ 'sources' ])
@@ -215,7 +217,8 @@ module.exports = function(app) {
       app.debug(description)
     }
 
-    defaultId = pilot.id ?? defaultId
+    pilot.id = defaultId
+    app.debug('*** post-discovery -> defaultId', defaultId)
       
     return {
       deviceid: {

--- a/raymarinen2k.js
+++ b/raymarinen2k.js
@@ -53,12 +53,14 @@ const everyone_dst = '255'
 
 module.exports = function(app) {
   var deviceid
-  var pilot = {}
+  var pilot = {id: null}
   var timers = []
   var discovered
 
   pilot.start = (props) => {
     deviceid = props.deviceid
+    pilot.id = Number(deviceid)
+    app.debug('props.deviceid:', deviceid)
 
     if ( props.controlHead ) {
       timers.push(setInterval(() => {
@@ -212,6 +214,8 @@ module.exports = function(app) {
       description = `Discovered an EV-1 with id ${discovered}`
       app.debug(description)
     }
+
+    defaultId = pilot.id ?? defaultId
       
     return {
       deviceid: {

--- a/raystngconv.js
+++ b/raystngconv.js
@@ -61,7 +61,7 @@ module.exports = function(app) {
 
   pilot.start = (props) => {
     deviceid = props.converterDeviceId
-    pilot.id = Number(deviceid)
+    pilot.id = deviceid
     app.debug('props.converterDeviceId:', deviceid)
   }
 
@@ -173,8 +173,10 @@ module.exports = function(app) {
   }
 
   pilot.properties = () => {
-    let defaultConverterId = '115'
+    let defaultConverterId = deviceid ?? '115'
     let description = 'No SeaTalk-STNG-Converter device found'
+
+    app.debug('***pre-discovery -> defaultConverterId', defaultConverterId)
       
     if ( !discovered ) {
       const sources = app.getPath('/sources')
@@ -192,12 +194,13 @@ module.exports = function(app) {
     }
 
     if ( discovered ) {
-      converterDeviceId = discovered
+      defaultConverterId = discovered
       description = `SeaTalk-STNG-Converter with id ${discovered} discovered`
       app.debug(description)
     }
 
-    defaultConverterId = pilot.id ?? defaultConverterId
+    pilot.id = defaultConverterId
+    app.debug('*** post-discovery -> defaultConverterId', defaultConverterId)
 
     return {
       converterDeviceId: {

--- a/raystngconv.js
+++ b/raystngconv.js
@@ -56,11 +56,13 @@ const everyone_dst = '255'
 
 module.exports = function(app) {
   var deviceid
-  var pilot = {}
+  var pilot = {id: null}
   var discovered
 
   pilot.start = (props) => {
     deviceid = props.converterDeviceId
+    pilot.id = Number(deviceid)
+    app.debug('props.converterDeviceId:', deviceid)
   }
 
   pilot.stop = () => {
@@ -194,6 +196,8 @@ module.exports = function(app) {
       description = `SeaTalk-STNG-Converter with id ${discovered} discovered`
       app.debug(description)
     }
+
+    defaultConverterId = pilot.id ?? defaultConverterId
 
     return {
       converterDeviceId: {


### PR DESCRIPTION
Add support for [Autopilot API](https://github.com/SignalK/signalk-server/pull/1596).

This PR is to assist in the development of the Autopilot API, specifically for interacting with autopilots via NMEA2000 / SeaTalk.


- [x] Register as autopilot provider
- [x] Action requests via API endpoints.
- [x] Update API with changes originating from autopilot device.
- [x] Update API with alarm notifcations.
- [x] Integrate with NMEA2000 stream events.


