### PR TITLE
Add heading support in adjust heading

### DIFF
--- a/src/simrad.ts
+++ b/src/simrad.ts
@@ -239,8 +239,8 @@ export default function (app: any): Autopilot {
     putAdjustHeading: (context: string, path: string, value: any, _cb: any) => {
       const state = app.getSelfPath(state_path)
 
-      if (state !== 'auto' && state !== 'wind') {
-        return { message: 'Autopilot not in auto or wind mode', ...FAILURE_RES }
+      if (state !== 'auto' && state !== 'heading' && state !== 'wind') {
+        return { message: 'Autopilot not in auto, heading or wind mode', ...FAILURE_RES }
       } else {
         const pgn = new PGN_130850_SimnetCommandApChangeCourse({
           address: pilot.id,


### PR DESCRIPTION
Auto mode on simrad autopilots is "noDrift" which follows a GPS heading. Heading mode follows a compass heading and can also support a change in heading.