### PR TITLE
chore(deps-dev): declare prettier explicitly, drop prettier-standard

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+coverage
+dist
+public
+.claude
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-prettier": "^5.5.3",
     "html-minimizer-webpack-plugin": "^4.4.0",
     "mocha": "^11.7.1",
-    "prettier-standard": "^16.4.1",
+    "prettier": "^3.8.2",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",


### PR DESCRIPTION
## Summary

`prettier-standard@^16.4.1` is listed in `devDependencies`, but nothing actually references it: every script (`prettier`, `ci-lint`, `format`) calls the plain `prettier` binary. The scripts worked only because `eslint-plugin-prettier` pulls prettier transitively — so whichever prettier version that plugin happened to install was what was actually formatting the tree. If `eslint-plugin-prettier` ever updates its prettier peer requirement, formatting output can shift without a commit here.

## Changes

- `package.json`: drop `prettier-standard`, add `prettier@^3.8.2` explicitly.
- `.prettierignore`: add a small ignore file matching the siblings (`nmea0183-signalk`, `nmea0183-utilities`, `signalk-to-nmea0183`, `signalk-derived-data`) so `prettier --write .` stays sane without relying on the explicit path list in the scripts.

The already-committed `.prettierrc.json` is unchanged — it already matched the siblings (`semi: false, singleQuote: true, trailingComma: "none"`).

## Test plan

- [x] `npm install` — resolves cleanly
- [x] `npm run ci-lint` — eslint + `prettier --check ./src/* ./test/*` both clean
- [x] `npm run build` — tsc succeeds
- [x] `npm test` — 32 passing
- [x] `prettier --version` — reports `3.8.2`
- [x] `prettier --check ./src/* ./test/*` against 3.8.2 — zero diff from the existing tree