### PR TITLE
perf: gate JSON.stringify behind debug.enabled in sendN2k

### DIFF
--- a/src/raymarinen2k.ts
+++ b/src/raymarinen2k.ts
@@ -586,7 +586,9 @@ export default function (app: any): Autopilot {
   }
 
   function sendN2k(msgs: any[]) {
-    app.debug('n2k_msg: ' + JSON.stringify(msgs))
+    if (app.debug.enabled) {
+      app.debug('n2k_msg: ' + JSON.stringify(msgs))
+    }
     msgs.map(function (msg) {
       if (typeof msg === 'string') {
         app.emit('nmea2000out', msg)

--- a/src/simrad.ts
+++ b/src/simrad.ts
@@ -357,7 +357,9 @@ export default function (app: any): Autopilot {
   }
 
   function sendN2k(msgs: PGN[]) {
-    app.debug('n2k_msg: ' + JSON.stringify(msgs))
+    if (app.debug.enabled) {
+      app.debug('n2k_msg: ' + JSON.stringify(msgs))
+    }
     msgs.map(function (msg) {
       if (typeof msg === 'string') {
         app.emit('nmea2000out', msg)


### PR DESCRIPTION
The two `sendN2k()` helpers (raymarinen + simrad) run

```ts
app.debug('n2k_msg: ' + JSON.stringify(msgs))
```

unconditionally on every NMEA-2000 send. With debug logging off (the production default), the `JSON.stringify` still runs eagerly, allocating short-lived strings that hammer the young-generation GC.

This is one of the bigger perf taxes a SignalK plugin pays: the serialize cost compounds with the GC pressure on hot paths. For reference, the same class of fix on `course-provider-plugin`'s dispatcher cut latency by ~70 % and dropped ~700 b/op of allocations on a single hot call site (#10 + follow-ups).

## Change

- `src/raymarinen2k.ts` — wrap with `if (app.debug.enabled)`.
- `src/simrad.ts` — same.

No behaviour change otherwise.