### PR TITLE
fix: hardware check for Raymarine EV-1 Course Computer

### DIFF
--- a/src/raymarinen2k.ts
+++ b/src/raymarinen2k.ts
@@ -508,10 +508,15 @@ export default function (app: any): Autopilot {
                 if (
                   v[id] &&
                   v[id].n2k &&
-                  v[id].n2k.hardwareVersion &&
-                  v[id].n2k.hardwareVersion.startsWith(
-                    'Raymarine EV-1 Course Computer'
-                  )
+                  ((
+                    v[id].n2k.hardwareVersion &&
+                    v[id].n2k.hardwareVersion.startsWith(
+                      'Raymarine EV-1 Course Computer'
+                    )) ||
+                    v[id].n2k.modelVersion &&
+                    v[id].n2k.modelVersion.startsWith(
+                      'Raymarine EV-1 Course Computer'
+                    ))
                 ) {
                   discovered = id
                 }


### PR DESCRIPTION
In the latest version, the EV-1 is not detected. The object is having `modelVersion` instead of `hardwareVersion`
This PR allows for both keys

```
May 31 23:09:18 2026-05-31T22:09:18.784Z @signalk/signalk-autopilot ***predis n2k --> { pgns: { '59392': '2026-05-31T22:09:14.258Z' }, uniqueNumber: 411442, manufacturerCode: 'Raymarine', deviceInstanceLower: 5, deviceInstanceUpper: 6, deviceFunction: 150, spare: 0, deviceClass: 'Steering and Control surfaces', systemInstance: 0, industryGroup: 'Marine Industry', arbitraryAddressCapable: 'Yes', deviceInstance: 53, canName: 'c0509635e7664732', unknownPGNs: { '59392': { canId: 417883340, prio: 6, src: 204, pgn: 59392, dst: 100, fields: [Object], description: 'ISO Acknowledgement', id: 'isoAcknowledgement', timestamp: '2026-05-31T22:09:14.258Z' }, '59904': { canId: 418032844, prio: 6, src: 204, pgn: 59904, dst: 172, fields: [Object], description: 'ISO Request', id: 'isoRequest', timestamp: '2026-05-31T22:08:59.996Z' }, '126208': { canId: 233680076, prio: 3, src: 204, pgn: 126208, dst: 172, fields: [Object], description: 'NMEA - Request group function', id: 'nmeaRequestGroupFunction', timestamp: '2026-05-31T22:09:04.564Z' } }, nmea2000Version: 1.301, productCode: 29086, modelId: 'E70096', softwareVersionCode: '3.05 (RSCP V1 L4)', modelVersion: 'Raymarine EV-1 Course Computer', modelSerialCode: '0411442', certificationLevel: 'Level B', loadEquivalency: 1, src: '204' }
```