### PR TITLE
Expose emulator v2 mode capabilities

### DIFF
--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -42,7 +42,7 @@ export default function (app: any): Autopilot {
             }
           ]
         }
-        if (currentState === 'auto' && currentTarget !== undefined) {
+        if ((currentState === 'auto' || currentState === 'route') && currentTarget !== undefined) {
           delta.updates[0].values.push({
             path: 'steering.autopilot.target.headingMagnetic',
             value: currentTarget
@@ -65,7 +65,8 @@ export default function (app: any): Autopilot {
       return [
         { name: 'standby', engaged: false },
         { name: 'auto', engaged: true },
-        { name: 'wind', engaged: true }
+        { name: 'wind', engaged: true },
+        { name: 'route', engaged: true }
       ]
     },
 
@@ -129,7 +130,7 @@ export default function (app: any): Autopilot {
         ]
       }
 
-      if (value === 'auto') {
+      if (value === 'auto' || value === 'route') {
         const heading = app.getSelfPath('navigation.headingMagnetic.value')
         if (heading !== undefined) {
           currentTarget = heading
@@ -210,12 +211,12 @@ export default function (app: any): Autopilot {
     putAdjustHeading: (context: string, path: string, value: any, _cb: any) => {
       const state = app.getSelfPath(state_path)
 
-      if (state !== 'auto' && state !== 'wind') {
+      if (state !== 'auto' && state !== 'wind' && state !== 'route') {
         return {
-          message: 'Autopilot not in auto or wind mode',
+          message: 'Autopilot not in auto, wind or route mode',
           ...FAILURE_RES
         }
-      } else if (state === 'auto') {
+      } else if (state === 'auto' || state === 'route') {
         const target = app.getSelfPath(
           'steering.autopilot.target.headingMagnetic.value'
         )
@@ -274,8 +275,15 @@ export default function (app: any): Autopilot {
       })
     },
 
-    putTack: (_context: string, _path: string, _value: any, _cb: any) => {
-      return { message: 'Unsupported', ...FAILURE_RES }
+    putTack: (_context: string, _path: string, value: any, _cb: any) => {
+      const state = app.getSelfPath(state_path)
+      if (state !== 'wind' && state !== 'auto') {
+        return { message: 'Autopilot not in wind or auto mode', ...FAILURE_RES }
+      }
+      if (value !== 'port' && value !== 'starboard') {
+        return { message: `Invalid tack direction: ${value}`, ...FAILURE_RES }
+      }
+      return SUCCESS_RES
     },
 
     putAdvanceWaypoint: (
@@ -284,7 +292,11 @@ export default function (app: any): Autopilot {
       _value: any,
       _cb: any
     ) => {
-      return { message: 'Unsupported', ...FAILURE_RES }
+      const state = app.getSelfPath(state_path)
+      if (state !== 'route') {
+        return { message: 'Autopilot not in route/track mode', ...FAILURE_RES }
+      }
+      return SUCCESS_RES
     },
 
     properties: () => {

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -37,7 +37,8 @@ export default function (app: any): Autopilot {
           updates: [
             {
               values: [
-                { path: 'steering.autopilot.state', value: currentState }
+                { path: 'steering.autopilot.state', value: currentState },
+                { path: 'steering.autopilot.mode', value: currentState }
               ]
             }
           ]
@@ -68,6 +69,10 @@ export default function (app: any): Autopilot {
         { name: 'wind', engaged: true },
         { name: 'route', engaged: true }
       ]
+    },
+
+    modes: () => {
+      return ['auto', 'wind', 'route']
     },
 
     putTargetHeadingPromise: (value: number) => {
@@ -125,7 +130,10 @@ export default function (app: any): Autopilot {
       const delta = {
         updates: [
           {
-            values: [{ path: 'steering.autopilot.state', value }]
+            values: [
+              { path: 'steering.autopilot.state', value },
+              { path: 'steering.autopilot.mode', value }
+            ]
           }
         ]
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,8 @@
 import {
   ActionResult,
   AutopilotProvider,
-  AutopilotInfo
+  AutopilotInfo,
+  AutopilotActionDef
 } from '@signalk/server-api'
 import raymarinen2k from './raymarinen2k'
 import raystngconv from './raystngconv'
@@ -61,6 +62,14 @@ const defaultEngagedMode = 'auto'
 const isValidState = (value: string) => {
   return apData.options.states.findIndex((i) => i.name === value) !== -1
 }
+
+const buildActions = (state: string | null, isDodging = false): AutopilotActionDef[] => [
+  { id: 'tack', name: 'Tack', available: state === 'wind' || state === 'auto' },
+  { id: 'gybe', name: 'Gybe', available: state === 'wind' || state === 'auto' },
+  { id: 'courseNextPoint', name: 'Advance Waypoint', available: state === 'route' },
+  { id: 'courseCurrentPoint', name: 'Steer to Waypoint', available: state !== 'route' && state !== null },
+  { id: 'dodge', name: 'Dodge', available: (state === 'auto' || state === 'wind' || state === 'route') && !isDodging }
+]
 
 export interface Autopilot {
   id: number
@@ -132,6 +141,9 @@ export default function (app: any) {
   const pilots: { [key: string]: Autopilot } = {}
   let apType = '' // autopilot type
   let lastState: string | undefined = undefined
+  let dodgeActive = false
+  let preDodgeState: string | null = null
+  let preDodgeTarget: number | null = null
 
   Object.keys(types).forEach((type) => {
     const module = types[type]
@@ -286,10 +298,15 @@ export default function (app: any) {
           }
         },
         getMode: async (_deviceId) => {
-          throw new Error('Not implemented!')
+          return apData.mode
         },
-        setMode: async (_mode, _deviceId) => {
-          throw new Error('Not implemented!')
+        setMode: async (mode, _deviceId) => {
+          // Raymarine/Simrad conflate mode and state
+          if (isValidState(mode)) {
+            return autopilot.putStatePromise(mode)
+          } else {
+            throw new Error(`${mode} is not a valid mode value!`)
+          }
         },
         getTarget: async (_deviceId) => {
           return apData.target as number
@@ -321,17 +338,95 @@ export default function (app: any) {
         tack: async (direction, _deviceId) => {
           return autopilot.putTackPromise(direction)
         },
-        gybe: async (_direction, _deviceId) => {
-          throw new Error('Not implemented!')
+        gybe: async (direction, _deviceId) => {
+          // Raymarine uses the same keystroke for tack and gybe —
+          // the pilot decides based on wind angle
+          return autopilot.putTackPromise(direction)
         },
-        dodge: async (_direction, _deviceId) => {
-          throw new Error('Not implemented!')
+        dodge: async (value, _deviceId) => {
+          if (value === null) {
+            // Cancel dodge — restore original state and target
+            if (!dodgeActive) {
+              throw new Error('Dodge mode is not active')
+            }
+            if (preDodgeState && preDodgeState !== apData.state) {
+              await autopilot.putStatePromise(preDodgeState)
+            }
+            if (preDodgeState !== 'route' && preDodgeTarget !== null) {
+              await autopilot.putTargetHeadingPromise(radiansToDegrees(preDodgeTarget))
+            }
+            dodgeActive = false
+            preDodgeState = null
+            preDodgeTarget = null
+            app.autopilotUpdate(apType, { actions: buildActions(apData.state, dodgeActive) })
+          } else if (value === 0) {
+            // Enter dodge — save current state, no course change yet
+            if (dodgeActive) {
+              throw new Error('Dodge mode is already active')
+            }
+            preDodgeState = apData.state
+            preDodgeTarget = apData.target
+            dodgeActive = true
+            if (apData.state === 'route') {
+              await autopilot.putStatePromise('auto')
+            }
+            app.autopilotUpdate(apType, { actions: buildActions(apData.state, dodgeActive) })
+          } else {
+            // Adjust dodge heading — decompose into ±10 and ±1 keystrokes
+            if (!dodgeActive) {
+              preDodgeState = apData.state
+              preDodgeTarget = apData.target
+              dodgeActive = true
+              if (apData.state === 'route') {
+                await autopilot.putStatePromise('auto')
+              }
+            }
+            let degrees = Math.round(radiansToDegrees(value))
+            const sign = degrees > 0 ? 1 : -1
+            degrees = Math.abs(degrees)
+            const tens = Math.floor(degrees / 10)
+            const ones = degrees % 10
+            for (let i = 0; i < tens; i++) {
+              await autopilot.putAdjustHeadingPromise(sign * 10)
+            }
+            for (let i = 0; i < ones; i++) {
+              await autopilot.putAdjustHeadingPromise(sign * 1)
+            }
+            app.autopilotUpdate(apType, { actions: buildActions(apData.state, dodgeActive) })
+          }
         },
         courseCurrentPoint: async (_deviceId: string): Promise<void> => {
-          throw new Error('Not implemented!')
+          // Per API spec: engage the appropriate mode to steer to the active waypoint
+          return autopilot.putStatePromise('route')
         },
         courseNextPoint: async (_deviceId: string): Promise<void> => {
-          throw new Error('Not implemented!')
+          const state = app.getSelfPath(state_path + '.value')
+          if (state !== 'route') {
+            throw new Error('Autopilot not in route/track mode')
+          }
+          const result = autopilot.putAdvanceWaypoint(
+            'vessels.self', advance, 1, undefined
+          )
+          if (result.state !== 'COMPLETED') {
+            throw new Error(result.message || 'Advance waypoint failed')
+          }
+          // Advance the server's course pointIndex.
+          // On real hardware the chartplotter may do this via N2K,
+          // but when SignalK manages the route we must do it here.
+          try {
+            const course = await app.courseApi.getCourse()
+            if (course?.activeRoute?.href) {
+              const nextIndex = (course.activeRoute.pointIndex ?? 0) + 1
+              await app.courseApi.activeRoute({
+                href: course.activeRoute.href,
+                reverse: course.activeRoute.reverse ?? false,
+                pointIndex: nextIndex,
+                arrivalCircle: course.arrivalCircle ?? 100
+              })
+            }
+          } catch (e: any) {
+            app.debug('courseNextPoint: failed to advance course', e?.message ?? e)
+          }
         }
       }
       app.registerAutopilotProvider(provider, [apType])
@@ -397,9 +492,13 @@ export default function (app: any) {
                 (i) => i.name === pathValue.value
               )
               apData.engaged = stateObj ? stateObj.engaged : false
+              // Update available actions based on current state
+              apData.options.actions = buildActions(apData.state, dodgeActive)
+
               app.autopilotUpdate(apType, {
                 state: apData.state,
-                engaged: apData.engaged
+                engaged: apData.engaged,
+                actions: apData.options.actions
               })
               if (apData.state != null && apData.state !== 'standby') {
                 lastState = apData.state

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,6 @@ const DEFAULT_TARGET_TYPES: { [k: string]: TargetType } = {
   route: 'route'
 }
 const DEFAULT_ROUTE_STATE = 'route'
-const DEFAULT_DODGE_FALLBACK_STATE = 'auto'
 
 const isValidState = (value: string) => {
   return apData.options.states.findIndex((i) => i.name === value) !== -1
@@ -334,8 +333,11 @@ export default function (app: any) {
   }
   const apDodgeFallbackState = (state: string): string | null => {
     if (autopilot?.dodgeFallbackState) return autopilot.dodgeFallbackState(state)
-    // Default: route mode can't dodge directly — switch to auto first.
-    return state === apRouteState() ? DEFAULT_DODGE_FALLBACK_STATE : null
+    // Default: route mode can't dodge directly — switch to the backend's
+    // own default engaged state instead of assuming a literal name.
+    if (state !== apRouteState()) return null
+    const fallback = apDefaultEngagedState()
+    return fallback && fallback !== apRouteState() ? fallback : null
   }
   // The "off" / disengaged state. Derived from the states-list metadata
   // (engaged: false) instead of hardcoding 'standby', so backends with a
@@ -434,9 +436,11 @@ export default function (app: any) {
             dodgeActive = false
             preDodgeState = null
             preDodgeTarget = null
-            app.autopilotUpdate(apType, {
-              actions: apActionsForState(apData.state, dodgeActive)
-            })
+            apData.options.actions = apActionsForState(
+              apData.state,
+              dodgeActive
+            )
+            app.autopilotUpdate(apType, { actions: apData.options.actions })
           } else if (value === 0) {
             // Enter dodge — save current state, no course change yet
             if (dodgeActive) {
@@ -451,9 +455,11 @@ export default function (app: any) {
             if (fallback) {
               await autopilot.putStatePromise(fallback)
             }
-            app.autopilotUpdate(apType, {
-              actions: apActionsForState(apData.state, dodgeActive)
-            })
+            apData.options.actions = apActionsForState(
+              apData.state,
+              dodgeActive
+            )
+            app.autopilotUpdate(apType, { actions: apData.options.actions })
           } else {
             // Adjust dodge heading — decompose into ±10 and ±1 keystrokes
             if (!dodgeActive) {
@@ -478,9 +484,11 @@ export default function (app: any) {
             for (let i = 0; i < ones; i++) {
               await autopilot.putAdjustHeadingPromise(sign * 1)
             }
-            app.autopilotUpdate(apType, {
-              actions: apActionsForState(apData.state, dodgeActive)
-            })
+            apData.options.actions = apActionsForState(
+              apData.state,
+              dodgeActive
+            )
+            app.autopilotUpdate(apType, { actions: apData.options.actions })
           }
         },
         courseCurrentPoint: async (_deviceId: string): Promise<void> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -295,12 +295,13 @@ export default function (app: any) {
           return apData.target as number
         },
         setTarget: async (value, _deviceId) => {
-          if (apData.mode === 'auto') {
+          const mode = apData.mode ?? apData.state
+          if (mode === 'auto') {
             return autopilot.putTargetHeadingPromise(radiansToDegrees(value))
-          } else if (apData.mode === 'wind') {
+          } else if (mode === 'wind') {
             return autopilot.putTargetWindPromise(radiansToDegrees(value))
           } else {
-            throw new Error(`Unable to set target value! MODE = ${apData.mode}`)
+            throw new Error(`Unable to set target value! MODE = ${mode}`)
           }
         },
         adjustTarget: async (value, _deviceId) => {
@@ -309,7 +310,10 @@ export default function (app: any) {
           )
         },
         engage: async (_deviceId) => {
-          return autopilot.putStatePromise(lastState || defaultEngagedMode)
+          const engageState = lastState || defaultEngagedMode
+          apData.state = engageState
+          apData.mode = engageState
+          return autopilot.putStatePromise(engageState)
         },
         disengage: async (_deviceId) => {
           return autopilot.putStatePromise('standby')
@@ -388,6 +392,7 @@ export default function (app: any) {
               apData.state = isValidState(pathValue.value)
                 ? pathValue.value
                 : null
+              apData.mode = apData.state
               const stateObj = apData.options.states.find(
                 (i) => i.name === pathValue.value
               )

--- a/src/index.ts
+++ b/src/index.ts
@@ -337,6 +337,13 @@ export default function (app: any) {
     // Default: route mode can't dodge directly — switch to auto first.
     return state === apRouteState() ? DEFAULT_DODGE_FALLBACK_STATE : null
   }
+  // The "off" / disengaged state. Derived from the states-list metadata
+  // (engaged: false) instead of hardcoding 'standby', so backends with a
+  // different label (or future ones with multiple disengaged states) work.
+  const apDisengagedState = (): string => {
+    const disengaged = apData.options.states.find((s) => !s.engaged)
+    return disengaged?.name ?? 'standby'
+  }
 
   // Autopilot API - register with Autopilot API
   const registerProvider = () => {
@@ -396,7 +403,7 @@ export default function (app: any) {
           return autopilot.putStatePromise(engageState)
         },
         disengage: async (_deviceId) => {
-          return autopilot.putStatePromise('standby')
+          return autopilot.putStatePromise(apDisengagedState())
         },
         tack: async (direction, _deviceId) => {
           return autopilot.putTackPromise(direction)
@@ -584,7 +591,7 @@ export default function (app: any) {
                 engaged: apData.engaged,
                 actions: apData.options.actions
               })
-              if (apData.state != null && apData.state !== 'standby') {
+              if (apData.state != null && apData.engaged) {
                 lastState = apData.state
               }
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,18 +58,40 @@ const apData: AutopilotInfo = {
   target: null
 }
 
-const defaultEngagedMode = 'auto'
+// Default target-type table used when the AP backend doesn't override
+// targetTypeForState(). Maps a state name to the kind of target value that
+// state expects: 'heading' (heading-target states), 'wind' (wind-vane states),
+// 'route' (route/track follows the active waypoint and has no settable target).
+type TargetType = 'heading' | 'wind' | 'route' | null
+const DEFAULT_TARGET_TYPES: { [k: string]: TargetType } = {
+  auto: 'heading',
+  wind: 'wind',
+  route: 'route'
+}
+const DEFAULT_ROUTE_STATE = 'route'
+const DEFAULT_DODGE_FALLBACK_STATE = 'auto'
+
 const isValidState = (value: string) => {
   return apData.options.states.findIndex((i) => i.name === value) !== -1
 }
 
-const buildActions = (state: string | null, isDodging = false): AutopilotActionDef[] => [
-  { id: 'tack', name: 'Tack', available: state === 'wind' || state === 'auto' },
-  { id: 'gybe', name: 'Gybe', available: state === 'wind' || state === 'auto' },
-  { id: 'courseNextPoint', name: 'Advance Waypoint', available: state === 'route' },
-  { id: 'courseCurrentPoint', name: 'Steer to Waypoint', available: state !== 'route' && state !== null },
-  { id: 'dodge', name: 'Dodge', available: (state === 'auto' || state === 'wind' || state === 'route') && !isDodging }
-]
+const buildDefaultActions = (
+  state: string | null,
+  isDodging: boolean,
+  routeState: string,
+  engagedStates: string[]
+): AutopilotActionDef[] => {
+  // Default Raymarine-shaped action availability. Backends with different
+  // vocabularies should override Autopilot.actionsForState().
+  const tackable = state === 'wind' || state === 'auto'
+  return [
+    { id: 'tack', name: 'Tack', available: tackable },
+    { id: 'gybe', name: 'Gybe', available: tackable },
+    { id: 'courseNextPoint', name: 'Advance Waypoint', available: state === routeState },
+    { id: 'courseCurrentPoint', name: 'Steer to Waypoint', available: state !== null && state !== routeState && engagedStates.includes(state) },
+    { id: 'dodge', name: 'Dodge', available: state !== null && engagedStates.includes(state) && !isDodging }
+  ]
+}
 
 export interface Autopilot {
   id: number
@@ -77,6 +99,15 @@ export interface Autopilot {
   stop(): void
   states?(): { name: string; engaged: boolean }[]
   modes?(): string[]
+
+  // Capability hooks — let backends declare what their state names mean,
+  // instead of index.ts guessing from Raymarine-shaped string literals.
+  defaultEngagedState?(): string
+  targetTypeForState?(state: string): TargetType
+  actionsForState?(state: string | null, isDodging: boolean): AutopilotActionDef[]
+  routeState?(): string
+  // State to switch to during dodge (e.g. route -> auto), or null to stay put.
+  dodgeFallbackState?(state: string): string | null
   putState(
     context: string | undefined,
     path: string | undefined,
@@ -276,6 +307,37 @@ export default function (app: any) {
     return config
   }
 
+  // Resolvers — ask the AP backend, fall back to a Raymarine-shaped default.
+  // Keeps state-name knowledge inside the backend that owns it.
+  const apTargetType = (state: string | null): TargetType => {
+    if (!state) return null
+    if (autopilot?.targetTypeForState) return autopilot.targetTypeForState(state)
+    return DEFAULT_TARGET_TYPES[state] ?? null
+  }
+  const apRouteState = (): string =>
+    autopilot?.routeState?.() ?? DEFAULT_ROUTE_STATE
+  const apDefaultEngagedState = (): string => {
+    if (autopilot?.defaultEngagedState) return autopilot.defaultEngagedState()
+    const firstEngaged = apData.options.states.find((s) => s.engaged)
+    return firstEngaged?.name ?? 'auto'
+  }
+  const apActionsForState = (
+    state: string | null,
+    isDodging: boolean
+  ): AutopilotActionDef[] => {
+    if (autopilot?.actionsForState)
+      return autopilot.actionsForState(state, isDodging)
+    const engagedStates = apData.options.states
+      .filter((s) => s.engaged)
+      .map((s) => s.name)
+    return buildDefaultActions(state, isDodging, apRouteState(), engagedStates)
+  }
+  const apDodgeFallbackState = (state: string): string | null => {
+    if (autopilot?.dodgeFallbackState) return autopilot.dodgeFallbackState(state)
+    // Default: route mode can't dodge directly — switch to auto first.
+    return state === apRouteState() ? DEFAULT_DODGE_FALLBACK_STATE : null
+  }
+
   // Autopilot API - register with Autopilot API
   const registerProvider = () => {
     app.debug('**** intialise Sk path subscriptions *****')
@@ -313,12 +375,13 @@ export default function (app: any) {
         },
         setTarget: async (value, _deviceId) => {
           const mode = apData.mode ?? apData.state
-          if (mode === 'auto') {
+          const targetType = apTargetType(mode)
+          if (targetType === 'heading') {
             return autopilot.putTargetHeadingPromise(radiansToDegrees(value))
-          } else if (mode === 'wind') {
+          } else if (targetType === 'wind') {
             return autopilot.putTargetWindPromise(radiansToDegrees(value))
           } else {
-            throw new Error(`Unable to set target value! MODE = ${mode}`)
+            throw new Error(`Unable to set target value! state = ${mode}`)
           }
         },
         adjustTarget: async (value, _deviceId) => {
@@ -327,7 +390,7 @@ export default function (app: any) {
           )
         },
         engage: async (_deviceId) => {
-          const engageState = lastState || defaultEngagedMode
+          const engageState = lastState || apDefaultEngagedState()
           apData.state = engageState
           apData.mode = engageState
           return autopilot.putStatePromise(engageState)
@@ -352,13 +415,21 @@ export default function (app: any) {
             if (preDodgeState && preDodgeState !== apData.state) {
               await autopilot.putStatePromise(preDodgeState)
             }
-            if (preDodgeState !== 'route' && preDodgeTarget !== null) {
-              await autopilot.putTargetHeadingPromise(radiansToDegrees(preDodgeTarget))
+            // Only restore a heading target — wind/route states manage their own.
+            if (
+              apTargetType(preDodgeState) === 'heading' &&
+              preDodgeTarget !== null
+            ) {
+              await autopilot.putTargetHeadingPromise(
+                radiansToDegrees(preDodgeTarget)
+              )
             }
             dodgeActive = false
             preDodgeState = null
             preDodgeTarget = null
-            app.autopilotUpdate(apType, { actions: buildActions(apData.state, dodgeActive) })
+            app.autopilotUpdate(apType, {
+              actions: apActionsForState(apData.state, dodgeActive)
+            })
           } else if (value === 0) {
             // Enter dodge — save current state, no course change yet
             if (dodgeActive) {
@@ -367,18 +438,26 @@ export default function (app: any) {
             preDodgeState = apData.state
             preDodgeTarget = apData.target
             dodgeActive = true
-            if (apData.state === 'route') {
-              await autopilot.putStatePromise('auto')
+            const fallback = preDodgeState
+              ? apDodgeFallbackState(preDodgeState)
+              : null
+            if (fallback) {
+              await autopilot.putStatePromise(fallback)
             }
-            app.autopilotUpdate(apType, { actions: buildActions(apData.state, dodgeActive) })
+            app.autopilotUpdate(apType, {
+              actions: apActionsForState(apData.state, dodgeActive)
+            })
           } else {
             // Adjust dodge heading — decompose into ±10 and ±1 keystrokes
             if (!dodgeActive) {
               preDodgeState = apData.state
               preDodgeTarget = apData.target
               dodgeActive = true
-              if (apData.state === 'route') {
-                await autopilot.putStatePromise('auto')
+              const fallback = preDodgeState
+                ? apDodgeFallbackState(preDodgeState)
+                : null
+              if (fallback) {
+                await autopilot.putStatePromise(fallback)
               }
             }
             let degrees = Math.round(radiansToDegrees(value))
@@ -392,16 +471,18 @@ export default function (app: any) {
             for (let i = 0; i < ones; i++) {
               await autopilot.putAdjustHeadingPromise(sign * 1)
             }
-            app.autopilotUpdate(apType, { actions: buildActions(apData.state, dodgeActive) })
+            app.autopilotUpdate(apType, {
+              actions: apActionsForState(apData.state, dodgeActive)
+            })
           }
         },
         courseCurrentPoint: async (_deviceId: string): Promise<void> => {
           // Per API spec: engage the appropriate mode to steer to the active waypoint
-          return autopilot.putStatePromise('route')
+          return autopilot.putStatePromise(apRouteState())
         },
         courseNextPoint: async (_deviceId: string): Promise<void> => {
           const state = app.getSelfPath(state_path + '.value')
-          if (state !== 'route') {
+          if (state !== apRouteState()) {
             throw new Error('Autopilot not in route/track mode')
           }
           const result = autopilot.putAdvanceWaypoint(
@@ -493,7 +574,10 @@ export default function (app: any) {
               )
               apData.engaged = stateObj ? stateObj.engaged : false
               // Update available actions based on current state
-              apData.options.actions = buildActions(apData.state, dodgeActive)
+              apData.options.actions = apActionsForState(
+                apData.state,
+                dodgeActive
+              )
 
               app.autopilotUpdate(apType, {
                 state: apData.state,
@@ -506,10 +590,11 @@ export default function (app: any) {
             }
 
             // map n2k device target value to API.target
+            const currentTargetType = apTargetType(apData.state)
             if (
               pathValue.path ===
                 'steering.autopilot.target.windAngleApparent' &&
-              apData.state === 'wind'
+              currentTargetType === 'wind'
             ) {
               apData.target = pathValue.value
               app.autopilotUpdate(apType, { target: pathValue.value })
@@ -519,7 +604,7 @@ export default function (app: any) {
               (pathValue.path === 'steering.autopilot.target.headingTrue' ||
                 pathValue.path ===
                   'steering.autopilot.target.headingMagnetic') &&
-              apData.state !== 'wind'
+              currentTargetType !== 'wind'
             ) {
               apData.target = pathValue.value
               app.autopilotUpdate(apType, { target: pathValue.value })

--- a/src/raymarinen2k.ts
+++ b/src/raymarinen2k.ts
@@ -419,8 +419,8 @@ export default function (app: any): Autopilot {
     putAdjustHeading: (context: string, path: string, value: any, _cb: any) => {
       const state = app.getSelfPath(state_path)
 
-      if (state !== 'auto' && state !== 'wind') {
-        return { message: 'Autopilot not in auto or wind mode', ...FAILURE_RES }
+      if (state !== 'auto' && state !== 'wind' && state !== 'route') {
+        return { message: 'Autopilot not in auto, wind or route mode', ...FAILURE_RES }
       } else {
         let aString
         switch (value) {

--- a/src/raymarinest.js
+++ b/src/raymarinest.js
@@ -244,6 +244,23 @@ module.exports = function (app) {
     }
   }
 
+  pilot.actionsForState = (state, isDodging) => {
+    const tackable = state === 'wind' || state === 'auto'
+    const engaged = state !== null && state !== 'standby'
+    return [
+      { id: 'tack', name: 'Tack', available: tackable },
+      { id: 'gybe', name: 'Gybe', available: tackable },
+      // Seatalk-1 putAdvanceWaypoint is unimplemented.
+      { id: 'courseNextPoint', name: 'Advance Waypoint', available: false },
+      {
+        id: 'courseCurrentPoint',
+        name: 'Steer to Waypoint',
+        available: engaged && state !== 'route'
+      },
+      { id: 'dodge', name: 'Dodge', available: engaged && !isDodging }
+    ]
+  }
+
   pilot.properties = () => {
     let defaultEvent = 'seatalkOut'
 

--- a/src/raystngconv.js
+++ b/src/raystngconv.js
@@ -185,8 +185,8 @@ module.exports = function (app) {
   pilot.putAdjustHeading = (context, path, value, _cb) => {
     var state = app.getSelfPath(state_path)
 
-    if (state !== 'auto' && state !== 'wind') {
-      return { message: 'Autopilot not in auto or wind mode', ...FAILURE_RES }
+    if (state !== 'auto' && state !== 'wind' && state !== 'route') {
+      return { message: 'Autopilot not in auto, wind or route mode', ...FAILURE_RES }
     } else {
       let aString
       switch (value) {

--- a/src/simrad.ts
+++ b/src/simrad.ts
@@ -45,9 +45,13 @@ const start_follow_up_command =
   '%s,2,130850,%s,255,12,41,9f,%s,ff,ff,02,0E,00,ff,ff,ff,ff'
 */
 
+// Simrad's native state vocabulary. "nodrift" was previously misnamed "auto"
+// to look raymarine-shaped — that conflated two distinct concepts (Simrad has
+// "nodrift" and "heading" as separate engaged modes; it has no "auto"). Renamed
+// to match what the device actually does.
 const states = [
   { name: 'standby', engaged: false },
-  { name: 'auto', engaged: true },
+  { name: 'nodrift', engaged: true },
   { name: 'wind', engaged: true },
   { name: 'route', engaged: true },
   { name: 'heading', engaged: true }
@@ -78,6 +82,50 @@ export default function (app: any): Autopilot {
 
     states: () => {
       return states
+    },
+
+    // "nodrift" and "heading" are both heading-target states; "wind" uses a
+    // wind target; "route" follows the active waypoint.
+    targetTypeForState: (state: string) => {
+      switch (state) {
+        case 'nodrift':
+        case 'heading':
+          return 'heading'
+        case 'wind':
+          return 'wind'
+        case 'route':
+          return 'route'
+        default:
+          return null
+      }
+    },
+
+    routeState: () => 'route',
+
+    defaultEngagedState: () => 'nodrift',
+
+    actionsForState: (state, isDodging) => {
+      const tackable =
+        state === 'wind' || state === 'nodrift' || state === 'heading'
+      return [
+        { id: 'tack', name: 'Tack', available: tackable },
+        { id: 'gybe', name: 'Gybe', available: tackable },
+        {
+          id: 'courseNextPoint',
+          name: 'Advance Waypoint',
+          available: state === 'route'
+        },
+        {
+          id: 'courseCurrentPoint',
+          name: 'Steer to Waypoint',
+          available: state !== null && state !== 'route' && state !== 'standby'
+        },
+        {
+          id: 'dodge',
+          name: 'Dodge',
+          available: state !== null && state !== 'standby' && !isDodging
+        }
+      ]
     },
 
     putTargetHeadingPromise: (value: number) => {
@@ -156,7 +204,7 @@ export default function (app: any): Autopilot {
           let pgn: PGN
 
           switch (value) {
-            case 'auto':
+            case 'nodrift':
               pgn = new PGN_130850_SimnetCommandApNodrift({
                 address: pilot.id,
                 unknown: 0
@@ -240,9 +288,9 @@ export default function (app: any): Autopilot {
     putAdjustHeading: (context: string, path: string, value: any, _cb: any) => {
       const state = app.getSelfPath(state_path)
 
-      if (state !== 'auto' && state !== 'heading' && state !== 'wind') {
+      if (state !== 'nodrift' && state !== 'heading' && state !== 'wind') {
         return {
-          message: 'Autopilot not in auto, heading or wind mode',
+          message: 'Autopilot not in nodrift, heading or wind mode',
           ...FAILURE_RES
         }
       } else {
@@ -274,8 +322,11 @@ export default function (app: any): Autopilot {
     putTack: (_context: string, _path: string, _value: any, _cb: any) => {
       const state = app.getSelfPath(state_path)
 
-      if (state !== 'wind' && state !== 'auto') {
-        return { message: 'Autopilot not in wind or auto mode', ...FAILURE_RES }
+      if (state !== 'wind' && state !== 'nodrift') {
+        return {
+          message: 'Autopilot not in wind or nodrift mode',
+          ...FAILURE_RES
+        }
       } else {
         sendN2k([
           new PGN_130850_SimnetCommandApTack({

--- a/src/simrad.ts
+++ b/src/simrad.ts
@@ -105,15 +105,16 @@ export default function (app: any): Autopilot {
     defaultEngagedState: () => 'nodrift',
 
     actionsForState: (state, isDodging) => {
-      const tackable =
-        state === 'wind' || state === 'nodrift' || state === 'heading'
+      // Tack matches putTack's state guard (wind/nodrift only).
+      const tackable = state === 'wind' || state === 'nodrift'
       return [
         { id: 'tack', name: 'Tack', available: tackable },
         { id: 'gybe', name: 'Gybe', available: tackable },
         {
           id: 'courseNextPoint',
           name: 'Advance Waypoint',
-          available: state === 'route'
+          // putAdvanceWaypoint is unimplemented for Simrad.
+          available: false
         },
         {
           id: 'courseCurrentPoint',

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -94,10 +94,13 @@ Object.entries(types).forEach(([name, type]) => {
       const autopilot: Autopilot = type(app)
       autopilot.start({})
 
+      // Simrad's heading-engaged state is "nodrift" (not "auto").
+      const engagedState = name === 'simrad' ? 'nodrift' : 'auto'
+
       const res = autopilot.putState(
         undefined,
         undefined,
-        'auto',
+        engagedState,
         (res: any) => {
           expect(res.state).to.equal('COMPLETED')
           done()
@@ -295,8 +298,9 @@ Object.entries(types).forEach(([name, type]) => {
         emulator: []
       }
 
+      const engagedState = name === 'simrad' ? 'nodrift' : 'auto'
       const app = new TestApp(expected[name], {
-        'steering.autopilot.state.value': 'auto'
+        'steering.autopilot.state.value': engagedState
       })
 
       const autopilot: Autopilot = type(app)

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -18,6 +18,28 @@ import { expect } from 'chai'
 import { types, Autopilot } from '../dist/index'
 import { TestApp, ExpectedEvent } from './utils'
 
+describe('test emulator autopilot', function () {
+  it('exposes v2 modes and publishes mode with state', () => {
+    const app = new TestApp([], {
+      'navigation.headingMagnetic.value': Math.PI / 2
+    })
+    const autopilot: Autopilot = types.emulator(app)
+    autopilot.start({})
+
+    try {
+      expect(autopilot.modes?.()).to.deep.equal(['auto', 'wind', 'route'])
+
+      const res = autopilot.putState(undefined, undefined, 'auto', () => {})
+
+      expect(res.statusCode).to.equal(200)
+      expect(app.getSelfPath('steering.autopilot.state.value')).to.equal('auto')
+      expect(app.getSelfPath('steering.autopilot.mode.value')).to.equal('auto')
+    } finally {
+      autopilot.stop()
+    }
+  })
+})
+
 Object.entries(types).forEach(([name, type]) => {
   if (name === 'emulator') {
     return


### PR DESCRIPTION
## Summary

Adds the missing V2 mode capability surface to the emulator autopilot.

This PR is intentionally limited to the simulator/emulator behavior:

- publishes `steering.autopilot.mode` alongside `steering.autopilot.state`
- exposes emulator V2 modes via `modes(): ['auto', 'wind', 'route']`
- adds an emulator-focused test for mode capability discovery and mode publication

## Context

This branch is stacked on #63, so the GitHub diff may include commits from #63 until that PR is merged. The simulator-specific change to review here is commit `33117ee`.

## Validation

- `npx eslint src/emulator.ts test/tests.ts`
- `npx tsx` direct emulator route/mode smoke test

`npm run build` is still blocked by the existing `src/simrad.ts` / `@canboat/ts-pgns` type mismatch present on the #63 base branch.
