### PR TITLE
feat(emulator): implement route mode with magnetic bearing and XTE correction

### DIFF
--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -19,8 +19,7 @@ import { toActionPromise } from './actionPromise'
 import { ActionResult } from '@signalk/server-api'
 
 const state_path = 'steering.autopilot.state.value'
-const routeTrackTruePath =
-  'navigation.course.calcValues.bearingTrackTrue.value'
+const routeTrackTruePath = 'navigation.course.calcValues.bearingTrackTrue.value'
 const routeTargetMagneticFallbackPaths = [
   'navigation.course.calcValues.bearingTrackMagnetic.value',
   'navigation.course.calcValues.bearingMagnetic.value'

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -19,6 +19,16 @@ import { toActionPromise } from './actionPromise'
 import { ActionResult } from '@signalk/server-api'
 
 const state_path = 'steering.autopilot.state.value'
+const routeTrackTruePath =
+  'navigation.course.calcValues.bearingTrackTrue.value'
+const routeTargetMagneticFallbackPaths = [
+  'navigation.course.calcValues.bearingTrackMagnetic.value',
+  'navigation.course.calcValues.bearingMagnetic.value'
+]
+const routeXtePath = 'navigation.course.calcValues.crossTrackError.value'
+const magneticVariationPath = 'navigation.magneticVariation.value'
+const defaultRouteXteLookahead = 100
+const defaultRouteMaxXteCorrection = 60
 
 const SUCCESS_RES = { state: 'COMPLETED', statusCode: 200 } as ActionResult
 const FAILURE_RES = { state: 'COMPLETED', statusCode: 400 } as ActionResult
@@ -29,10 +39,19 @@ export default function (app: any): Autopilot {
   let currentState = 'standby'
   let currentTarget: any = undefined
   let stateInterval: any
+  let routeXteLookahead = defaultRouteXteLookahead
+  let routeMaxXteCorrection = degsToRad(defaultRouteMaxXteCorrection)
 
   const pilot: Autopilot = {
     id: 10,
-    start: (_props) => {
+    start: (props) => {
+      routeXteLookahead =
+        positiveFinite(props?.routeXteLookahead) || defaultRouteXteLookahead
+      routeMaxXteCorrection = degsToRad(
+        positiveFinite(props?.routeMaxXteCorrection) ||
+          defaultRouteMaxXteCorrection
+      )
+
       stateInterval = setInterval(() => {
         const delta = {
           updates: [
@@ -43,7 +62,14 @@ export default function (app: any): Autopilot {
             }
           ]
         }
-        if (currentState === 'auto' && currentTarget !== undefined) {
+        if (currentState === 'route') {
+          currentTarget = getRouteTargetHeading()
+        }
+
+        if (
+          (currentState === 'auto' || currentState === 'route') &&
+          currentTarget !== undefined
+        ) {
           delta.updates[0].values.push({
             path: 'steering.autopilot.target.headingMagnetic',
             value: currentTarget
@@ -115,6 +141,16 @@ export default function (app: any): Autopilot {
         delta.updates[0].values.push({
           path: 'steering.autopilot.target.windAngleApparent',
           value: windAngle
+        })
+      } else if (value === 'route') {
+        const heading =
+          getRouteTargetHeading() ||
+          app.getSelfPath('navigation.headingMagnetic.value') ||
+          0
+        currentTarget = heading
+        delta.updates[0].values.push({
+          path: 'steering.autopilot.target.headingMagnetic',
+          value: heading
         })
       }
 
@@ -250,13 +286,77 @@ export default function (app: any): Autopilot {
     },
 
     properties: () => {
-      return {}
+      return {
+        routeXteLookahead: {
+          type: 'number',
+          title: 'Emulator route XTE lookahead distance',
+          description:
+            'Cross-track error distance, in meters, that produces about half the maximum route correction.',
+          default: defaultRouteXteLookahead
+        },
+        routeMaxXteCorrection: {
+          type: 'number',
+          title: 'Emulator route maximum XTE correction',
+          description:
+            'Maximum heading correction applied in route mode, in degrees.',
+          default: defaultRouteMaxXteCorrection
+        }
+      }
     }
   }
 
   return pilot
+
+  function getRouteTargetHeading() {
+    const trackHeadingTrue = app.getSelfPath(routeTrackTruePath)
+    if (Number.isFinite(trackHeadingTrue)) {
+      return trueHeadingToMagnetic(
+        correctedRouteHeading(trackHeadingTrue),
+        app.getSelfPath(magneticVariationPath)
+      )
+    }
+
+    for (const path of routeTargetMagneticFallbackPaths) {
+      const value = app.getSelfPath(path)
+      if (Number.isFinite(value)) {
+        return correctedRouteHeading(value)
+      }
+    }
+    return undefined
+  }
+
+  function correctedRouteHeading(trackHeading: number) {
+    const xte = app.getSelfPath(routeXtePath)
+    if (!Number.isFinite(xte)) {
+      return compassAngle(trackHeading)
+    }
+
+    const correction = clamp(
+      -Math.atan(xte / routeXteLookahead),
+      -routeMaxXteCorrection,
+      routeMaxXteCorrection
+    )
+    return compassAngle(trackHeading + correction)
+  }
 }
 
 function degsToRad(degrees: number) {
   return degrees * (Math.PI / 180.0)
+}
+
+function trueHeadingToMagnetic(headingTrue: number, magneticVariation: number) {
+  if (!Number.isFinite(magneticVariation)) return compassAngle(headingTrue)
+  return compassAngle(headingTrue - magneticVariation)
+}
+
+function compassAngle(angle: number) {
+  return ((angle % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI)
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+function positiveFinite(value: any) {
+  return Number.isFinite(value) && value > 0 ? value : undefined
 }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -19,6 +19,32 @@ import { types, Autopilot } from '../dist/index'
 import { TestApp, ExpectedEvent } from './utils'
 
 describe('test emulator autopilot', function () {
+  it('uses cross-track error to correct route target heading', () => {
+    const app = new TestApp([], {
+      'navigation.course.calcValues.bearingTrackTrue.value': Math.PI / 2,
+      'navigation.magneticVariation.value': Math.PI / 18,
+      'navigation.course.calcValues.crossTrackError.value': 500
+    })
+
+    const autopilot: Autopilot = types.emulator(app)
+    autopilot.start({ routeXteLookahead: 500, routeMaxXteCorrection: 45 })
+
+    try {
+      autopilot.putState(undefined, undefined, 'route')
+      expect(
+        app.getSelfPath('steering.autopilot.target.headingMagnetic.value')
+      ).to.be.closeTo((7 * Math.PI) / 36, 0.000001)
+
+      app.paths['navigation.course.calcValues.crossTrackError.value'] = -500
+      autopilot.putState(undefined, undefined, 'route')
+      expect(
+        app.getSelfPath('steering.autopilot.target.headingMagnetic.value')
+      ).to.be.closeTo((25 * Math.PI) / 36, 0.000001)
+    } finally {
+      autopilot.stop()
+    }
+  })
+
   it('exposes route as an available mode', () => {
     const app = new TestApp([])
     const autopilot: Autopilot = types.emulator(app)


### PR DESCRIPTION
## Summary

Implements route mode steering in the emulator autopilot.

When in route mode the emulator:

- reads the true-track bearing from `navigation.course.calcValues.bearingTrackTrue.value` and converts it to a magnetic heading using `navigation.magneticVariation.value`
- falls back to `navigation.course.calcValues.bearingTrackMagnetic.value` or `navigation.course.calcValues.bearingMagnetic.value` when no true bearing is available
- applies a cross-track error correction using an atan-based formula, clamped to a configurable maximum

Two configurable plugin properties are exposed:

| Property | Default | Description |
|---|---|---|
| `routeXteLookahead` | 100 m | XTE distance that produces ~50 % of the maximum correction |
| `routeMaxXteCorrection` | 60 ° | Hard clamp on the correction angle |

The route target heading is recomputed every tick of the broadcast interval.

## Context

Rebased on current master (includes #77). Builds and all 35 tests pass.

Stacks on #78 (expose emulator v2 mode capabilities) — the diff relative to that PR is `src/emulator.ts` and `test/tests.ts` only.

## Validation

- `npm run build` — clean
- `npm test` — 35 passing
- Includes a test that verifies the XTE geometry for both port and starboard deviation (500 m lookahead, 45° max correction)