### PR TITLE
feat(emulator): implement putTargetWind and direction-aware putTack

### DIFF
--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -129,8 +129,34 @@ export default function (app: any): Autopilot {
         pilot.putTargetWind(undefined, undefined, value, cb)
       ),
 
-    putTargetWind: (_context: string, _path: string, _value: any, _cb: any) => {
-      return { message: 'Unsupported', ...FAILURE_RES }
+    putTargetWind: (_context: string, _path: string, value: any, _cb: any) => {
+      const state = app.getSelfPath(state_path)
+      const targetDegrees = Number(value)
+
+      if (state !== 'wind') {
+        return { message: 'Autopilot not in wind mode', ...FAILURE_RES }
+      }
+      if (!Number.isFinite(targetDegrees)) {
+        return { message: 'Invalid wind target', ...FAILURE_RES }
+      }
+
+      const newTarget = degsToRad(targetDegrees)
+      currentTarget = newTarget
+
+      app.handleMessage(source, {
+        updates: [
+          {
+            values: [
+              {
+                path: 'steering.autopilot.target.windAngleApparent',
+                value: newTarget
+              }
+            ]
+          }
+        ]
+      })
+
+      return SUCCESS_RES
     },
 
     putAdjustHeadingPromise: (value: number) =>
@@ -200,30 +226,35 @@ export default function (app: any): Autopilot {
     putTack: (_context: string, _path: string, value: any, _cb: any) => {
       const state = app.getSelfPath(state_path)
 
-      if (state !== 'wind' && state !== 'auto') {
-        return { message: 'Autopilot not in wind or auto mode', ...FAILURE_RES }
+      if (state !== 'wind') {
+        return { message: 'Autopilot not in wind mode', ...FAILURE_RES }
+      }
+      if (value !== 'port' && value !== 'starboard') {
+        return { message: 'Unsupported tack direction', ...FAILURE_RES }
       }
 
-      // Simulate by reflecting the apparent wind target across 0 — emulates
-      // the boat coming through head-to-wind onto the opposite tack.
-      if (state === 'wind' && currentTarget !== undefined) {
-        currentTarget = -currentTarget
-        app.handleMessage(source, {
-          updates: [
-            {
-              values: [
-                {
-                  path: 'steering.autopilot.target.windAngleApparent',
-                  value: currentTarget
-                }
-              ]
-            }
-          ]
-        })
-      }
+      const target = app.getSelfPath(
+        'steering.autopilot.target.windAngleApparent.value'
+      )
+      const reference = Number.isFinite(target)
+        ? target
+        : app.getSelfPath('environment.wind.angleApparent.value')
+      const newTarget = (value === 'port' ? -1 : 1) * Math.abs(reference || 0)
+      currentTarget = newTarget
 
-      // Direction is informational for emulation; the math is symmetric.
-      void value
+      app.handleMessage(source, {
+        updates: [
+          {
+            values: [
+              {
+                path: 'steering.autopilot.target.windAngleApparent',
+                value: newTarget
+              }
+            ]
+          }
+        ]
+      })
+
       return SUCCESS_RES
     },
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -33,6 +33,25 @@ describe('test emulator autopilot', function () {
     }
   })
 
+  it('sets the absolute apparent wind target in wind mode', () => {
+    const app = new TestApp([], {
+      'steering.autopilot.state.value': 'wind'
+    })
+
+    const autopilot: Autopilot = types.emulator(app)
+    autopilot.start({})
+
+    try {
+      const res = autopilot.putTargetWind(undefined, undefined, -30)
+      expect(res.statusCode).to.equal(200)
+      expect(
+        app.getSelfPath('steering.autopilot.target.windAngleApparent.value')
+      ).to.be.closeTo(-Math.PI / 6, 0.000001)
+    } finally {
+      autopilot.stop()
+    }
+  })
+
   it('tacks by flipping the target apparent wind angle side', () => {
     const app = new TestApp([], {
       'steering.autopilot.state.value': 'wind',


### PR DESCRIPTION
## Summary

Implements wind target control and corrects tack direction semantics in the emulator.

### putTargetWind

Previously returned `Unsupported`. Now accepts a degree value, converts to radians, updates the internal target, and publishes `steering.autopilot.target.windAngleApparent`. Validates that the autopilot is in wind mode and that the value is finite.

### putTack

Replaces the simple negation (`-currentTarget`) with direction-aware logic:

- validates the direction argument (`port` | `starboard`) and rejects unknown values
- `port` → negative angle, `starboard` → positive angle, using `Math.abs` on the current target
- falls back to `environment.wind.angleApparent` if no target is set yet
- restricted to wind mode only (tacking via wind angle is not meaningful in auto/heading mode)

## Context

Stacks on #83 (`feat/emulator-expose-modes`), which exposes `wind` as a V2 mode. Once #83 is merged into master, this PR's diff will show only the wind-specific changes.

Builds cleanly and all 35 tests pass, including a new test for `putTargetWind`.

## Validation

- `npm run build` — clean
- `npm test` — 35 passing