### PR TITLE
fix(gui): use sans-serif font in autopilot webapp

### DIFF
--- a/public-src/index.html
+++ b/public-src/index.html
@@ -14,6 +14,7 @@
       margin: 0;
       padding: 0;
       overflow: hidden;
+      font-family: sans-serif;
     }
 
     #main {


### PR DESCRIPTION
The webapp's `index.html` set no `font-family`, so all GUI text (heading, AUTO/WIND/TRACK/STANDBY labels, +/-1, +/-10) fell back to the browser default, which renders as a serif on many platforms.

This is purely an aesthetic change: a sans-serif typeface looks cleaner and more modern, and matches the flat, icon-based look of the remote.

Source-only change in `public-src/index.html` (the built `public/index.html` is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)