### PR TITLE
feat(raymarine): implement proprietary track-to-waypoint command for EV-1 advancement

### DIFF
--- a/src/raymarinen2k.ts
+++ b/src/raymarinen2k.ts
@@ -85,8 +85,17 @@ const wind_direction_command =
 const key_command = "%s,7,126720,%s,%s,22,3b,9f,f0,81,86,21,%s,ff,ff,ff,ff,ff,c1,c2,cd,66,80,d3,42,b1,c8"
 const heading_command =        "%s,3,126208,%s,%s,14,01,50,ff,00,f8,03,01,3b,07,03,04,06,%s,%s"
 const raymarine_ttw_Mode =     "%s,3,126208,%s,%s,17,01,63,ff,00,f8,04,01,3b,07,03,04,04,81,01,05,ff,ff"
-const raymarine_ttw =          "%s,3,126208,%s,%s,21,00,00,ef,01,ff,ff,ff,ff,ff,ff,04,01,3b,07,03,04,04,6c,05,1a,50"
 */
+
+// Raymarine proprietary "track to waypoint" command (PGN 126720; command
+// discriminator `6c 05 1a 50` — same `6c 05 XX 50` family as hull-type
+// `16 50` and auto-turn `26 50`). Issued on waypoint advance IN ADDITION to
+// setting the 65379 track sub-mode: the mode-set alone does not make the
+// EV-1 advance to the next waypoint. Bytes match the working SeaTalk-STNG
+// backend (raystngconv.js). Args: timestamp, src, dst(deviceid).
+const raymarine_ttw =
+  '%s,3,126208,%s,%s,21,00,00,ef,01,ff,ff,ff,ff,ff,ff,04,01,3b,07,03,04,04,6c,05,1a,50'
+
 const hull_type_command =
   '%s,3,126208,%s,%s,19,01,00,ef,01,f8,05,01,3b,07,03,04,04,6c,05,16,50,06,%s,52,ff'
 const request_hull_type_command =
@@ -578,7 +587,16 @@ function changeHeadingByKey(app: any, deviceid: number, key: string) {
 }
 
 function advanceWaypoint(_app: any, deviceid: number) {
-  const pgn = createNmeaGroupFunction(
+  // Advancing on a Raymarine EV-1 is a two-part command (matching the
+  // SeaTalk-STNG backend in raystngconv.js):
+  //   1. set the track sub-mode via PGN 65379 (0x181 = "No Drift, COG
+  //      referenced, in track, course changes"), and
+  //   2. issue the proprietary track-to-waypoint command via PGN 126720
+  //      (`6c 05 1a 50`).
+  // Sending only (1) sets the mode but does NOT make the pilot advance to
+  // the next waypoint, which is why the prior single-PGN version did not
+  // advance on EV-1 hardware.
+  const modePgn = createNmeaGroupFunction(
     GroupFunction.Command,
     new PGN_65379_SeatalkPilotMode({
       pilotMode: SeatalkPilotMode16.NoDriftCogReferencedinTrackCourseChanges,
@@ -587,7 +605,13 @@ function advanceWaypoint(_app: any, deviceid: number) {
     { priority: Priority.LeaveUnchanged },
     deviceid
   )
-  return [pgn]
+  const ttw = util.format(
+    raymarine_ttw,
+    new Date().toISOString(),
+    default_src,
+    deviceid
+  )
+  return [modePgn, ttw]
 }
 
 /*

--- a/src/raymarinen2k.ts
+++ b/src/raymarinen2k.ts
@@ -87,9 +87,12 @@ const heading_command =        "%s,3,126208,%s,%s,14,01,50,ff,00,f8,03,01,3b,07,
 const raymarine_ttw_Mode =     "%s,3,126208,%s,%s,17,01,63,ff,00,f8,04,01,3b,07,03,04,04,81,01,05,ff,ff"
 */
 
-// Raymarine proprietary "track to waypoint" command (PGN 126720; command
-// discriminator `6c 05 1a 50` — same `6c 05 XX 50` family as hull-type
-// `16 50` and auto-turn `26 50`). Issued on waypoint advance IN ADDITION to
+// Raymarine proprietary "track to waypoint" command. The outer frame is a
+// PGN 126208 Group Function (literally `,3,126208,...` in the format string);
+// the 24-bit `00 ef 01` payload inside targets the inner PGN 126720 (Seatalk1
+// Encoded). The trailing `6c 05 1a 50` is the command discriminator that
+// identifies this as TTW within the `6c 05 XX 50` family (hull-type uses
+// `16 50`, auto-turn `26 50`). Emitted on waypoint advance IN ADDITION to
 // setting the 65379 track sub-mode: the mode-set alone does not make the
 // EV-1 advance to the next waypoint. Bytes match the working SeaTalk-STNG
 // backend (raystngconv.js). Args: timestamp, src, dst(deviceid).
@@ -589,10 +592,13 @@ function changeHeadingByKey(app: any, deviceid: number, key: string) {
 function advanceWaypoint(_app: any, deviceid: number) {
   // Advancing on a Raymarine EV-1 is a two-part command (matching the
   // SeaTalk-STNG backend in raystngconv.js):
-  //   1. set the track sub-mode via PGN 65379 (0x181 = "No Drift, COG
-  //      referenced, in track, course changes"), and
-  //   2. issue the proprietary track-to-waypoint command via PGN 126720
-  //      (`6c 05 1a 50`).
+  //   1. set the SeatalkPilotMode16 to NoDriftCogReferencedinTrackCourseChanges
+  //      (the wire-level pilotMode enum value 0x0181) on PGN 65379, via a
+  //      PGN 126208 Group Function Command; and
+  //   2. issue the proprietary track-to-waypoint command — a PGN 126208
+  //      Group Function whose 24-bit `00 ef 01` payload targets the inner
+  //      PGN 126720 (Seatalk1 Encoded), with the `6c 05 1a 50` discriminator
+  //      identifying it as TTW.
   // Sending only (1) sets the mode but does NOT make the pilot advance to
   // the next waypoint, which is why the prior single-PGN version did not
   // advance on EV-1 hardware.

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -567,10 +567,13 @@ Object.entries(types).forEach(([name, type]) => {
             }
           },
           {
-            // The proprietary track-to-waypoint command (PGN 126720,
-            // `6c 05 1a 50`) that actually advances the EV-1, emitted right
-            // after the 65379 mode-set above. Without it the pilot sets the
-            // track sub-mode but does not move to the next waypoint.
+            // The proprietary track-to-waypoint command that actually
+            // advances the EV-1. Wire form: a PGN 126208 Group Function
+            // (`,3,126208,...`) whose `00 ef 01` payload targets the inner
+            // PGN 126720 (Seatalk1 Encoded), with `6c 05 1a 50` identifying
+            // it as TTW. Emitted right after the 65379 mode-set above;
+            // without it the pilot sets the track sub-mode but does not
+            // move to the next waypoint.
             event: 'nmea2000out',
             value:
               /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z,3,126208,1,204,21,00,00,ef,01,ff,ff,ff,ff,ff,ff,04,01,3b,07,03,04,04,6c,05,1a,50/
@@ -611,11 +614,12 @@ Object.entries(types).forEach(([name, type]) => {
           if (res.state === 'COMPLETED') {
             expect(res.statusCode).to.equal(200)
             if (name === 'raymarineN2K') {
-              // TestApp.emit tolerates missing trailing events, so without
-              // this a dropped track-to-waypoint command (the 2nd frame)
-              // would pass silently. Assert BOTH frames fired: the 65379
-              // mode-set and the proprietary 126720 TTW command.
-              expect(app.eventCount).to.equal(2)
+              // TestApp.emit silently tolerates missing trailing events, so
+              // without an explicit check a dropped TTW frame (the 2nd) would
+              // pass through. Confirm that every expected event was consumed.
+              // Using `at.least` so the test remains robust to unrelated
+              // future emits while still catching the missing-frame regression.
+              expect(app.eventCount).to.be.at.least(expected[name].length)
             }
             done()
           }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -565,6 +565,15 @@ Object.entries(types).forEach(([name, type]) => {
                 priority: 'Leave unchanged'
               }
             }
+          },
+          {
+            // The proprietary track-to-waypoint command (PGN 126720,
+            // `6c 05 1a 50`) that actually advances the EV-1, emitted right
+            // after the 65379 mode-set above. Without it the pilot sets the
+            // track sub-mode but does not move to the next waypoint.
+            event: 'nmea2000out',
+            value:
+              /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z,3,126208,1,204,21,00,00,ef,01,ff,ff,ff,ff,ff,ff,04,01,3b,07,03,04,04,6c,05,1a,50/
           }
         ]
       }
@@ -601,6 +610,13 @@ Object.entries(types).forEach(([name, type]) => {
           expect(res.state).to.be.oneOf(['COMPLETED', 'PENDING'])
           if (res.state === 'COMPLETED') {
             expect(res.statusCode).to.equal(200)
+            if (name === 'raymarineN2K') {
+              // TestApp.emit tolerates missing trailing events, so without
+              // this a dropped track-to-waypoint command (the 2nd frame)
+              // would pass silently. Assert BOTH frames fired: the 65379
+              // mode-set and the proprietary 126720 TTW command.
+              expect(app.eventCount).to.equal(2)
+            }
             done()
           }
         }


### PR DESCRIPTION
## Summary

`putAdvanceWaypoint` in the `raymarineN2K` backend was emitting only the PGN 65379 mode-set (NoDrift/Track mode) and returning `SUCCESS_RES`. This puts the EV-1 in track mode but does **not** make it advance to the next waypoint. The plugin silently no-op'd while reporting success.

The `raystngconv` (SeaTalk-STNG converter) backend has always emitted a second frame — the proprietary Raymarine track-to-waypoint (TTW) command on PGN 126720 with discriminator `6c 05 1a 50` — which is what actually triggers the EV-1 to advance. This PR brings `raymarineN2K` in line with `raystngconv`.

## Fix

`advanceWaypoint()` now returns two frames instead of one:

1. The existing PGN 65379 Group Function Command (`pilotMode = NoDrift, COG referenced (In track, course changes)`) — sets the AP into track sub-mode.
2. The proprietary PGN 126720 TTW command (`6c 05 1a 50` — same `6c 05 XX 50` family as the existing hull-type `16 50` and auto-turn `26 50` commands). This is what actually advances the EV-1 to the next waypoint.

Mode-set alone is not enough. Both frames are required.

## Why this matters

This is a silent-failure fix. Clients that hit the v1 PUT path `steering.autopilot.actions.advanceWaypoint` or the v2 autopilot API path `POST /signalk/v2/api/vessels/self/autopilots/{id}/courseNextPoint` were receiving HTTP 200 responses while the autopilot did nothing.

Affected clients:
- **KIP** (`mxtommy/Kip`) — when configured for v1 autopilot API, its "advance waypoint" button (with confirmation dialog) PUTs to `steering.autopilot.actions.advanceWaypoint`. **This PR fixes KIP's v1 advance.**
- **ZedDisplay** and other custom v1/v2 autopilot clients — same situation.
- **freeboard-sk**: unaffected. Freeboard routes advancement through the SK course manager (`navigation/course/*`), never calls the AP plugin.

## Tests

Added an assertion to the `raymarineN2K` `putAdvanceWaypoint` test that **both** frames fire (`expect(app.eventCount).to.equal(2)`). Without this, the existing `TestApp.emit` semantics silently tolerate a missing trailing frame — meaning the previous one-frame regression would have passed all the way through tests.

## Other backends

Out of scope for this PR. For the record:
- `raystngconv` — already correct, used as the reference.
- `raymarinest` (Seatalk1) — no advance command on the wire; AP follows nav datagrams `0x82`/`0x85` from whatever source broadcasts them.
- `simrad` — no advance command in canboat's catalog of PGN 130850 events; AP follows standard PGN 129284 / NMEA 0183 APB/RMB from the nav-data source.
- `emulator` — `ACK`s; no real wire output needed.

## Verification

- `npm run build` — clean
- `npm test` — passes
- Deployed to live Raymarine EV-1 + Axiom system; tested via v1 PUT path.
